### PR TITLE
Add jUnit tests for ListCommand

### DIFF
--- a/src/test/java/seedu/commands/ListCommandTest.java
+++ b/src/test/java/seedu/commands/ListCommandTest.java
@@ -34,8 +34,7 @@ public class ListCommandTest {
     }
     @Test
     private void assertEmptyListMessage() throws SysLibException {
-
-        String outputMessage = testUtil.getOutputMessage(listCommand, "list");
+        String outputMessage = testUtil.getOutputMessage(listCommand, "list", emptyResourceList);
         String expectedMessage = "There are 0 resources in the library. " + System.lineSeparator();
         expectedMessage += System.lineSeparator();
         assertEquals(expectedMessage, outputMessage);

--- a/src/test/java/seedu/commands/ListCommandTest.java
+++ b/src/test/java/seedu/commands/ListCommandTest.java
@@ -1,0 +1,84 @@
+package seedu.commands;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import seedu.data.Resource;
+import seedu.data.SysLibException;
+import seedu.parser.Parser;
+import seedu.util.TestUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ListCommandTest {
+
+
+    private Parser parser = new Parser();
+    private List<Resource> emptyResourceList = new ArrayList<>();
+    private List<Resource> testResourceList = new ArrayList<>();
+    private TestUtil testUtil = new TestUtil();
+
+    private Command listCommand = new ListCommand();
+
+
+
+    @Test
+    void execute() throws SysLibException {
+        testResourceList = TestUtil.fillTestList();
+        assertEmptyListMessage();
+        assertListByTagBehavior();
+        assertListByGenreBehavior();
+        assertNoFilteredListDisplay();
+    }
+    @Test
+    /**
+     * Asserts that there are no errors when list is called and there are no resources in the library
+     */
+    private void assertEmptyListMessage() throws SysLibException {
+
+        String outputMessage = testUtil.getOutputMessage(listCommand, "list");
+        String expectedMessage = "There are 0 resources in the library. " + System.lineSeparator();
+        expectedMessage += System.lineSeparator();
+        assertEquals(expectedMessage, outputMessage);
+
+    }
+
+    @Test
+    /**
+     * Asserts that there an exception is thrown when the user enters a /tag without a value
+     */
+    private void assertListByTagBehavior() {
+        parser.resourceList = testResourceList;
+        assertThrows(SysLibException.class, ()->listCommand.execute("/tag", parser));
+
+    }
+
+    @Test
+    /**
+     * Asserts that there an exception is thrown when the user enters a /g without a value
+     */
+    private void assertListByGenreBehavior()  {
+        parser.resourceList = testResourceList;
+        assertThrows(SysLibException.class, ()->listCommand.execute("/g", parser));
+
+    }
+
+    @Test
+    /**
+     * Asserts that there is no error when there are no resources to list with given filters.
+     */
+    private void assertNoFilteredListDisplay() throws SysLibException {
+        String outputMessage = testUtil.getOutputMessage(listCommand, "list /g Thriller", testResourceList);
+        String expectedMessage = "Listing all resources matching given genre: " + System.lineSeparator()
+                + System.lineSeparator();
+        expectedMessage += "There are currently 0 resource(s)." + System.lineSeparator();
+        expectedMessage += System.lineSeparator();
+        assertEquals(expectedMessage, outputMessage);
+
+    }
+
+    
+
+}

--- a/src/test/java/seedu/commands/ListCommandTest.java
+++ b/src/test/java/seedu/commands/ListCommandTest.java
@@ -33,9 +33,6 @@ public class ListCommandTest {
         assertNoFilteredListDisplay();
     }
     @Test
-    /**
-     * Asserts that there are no errors when list is called and there are no resources in the library
-     */
     private void assertEmptyListMessage() throws SysLibException {
 
         String outputMessage = testUtil.getOutputMessage(listCommand, "list");
@@ -46,19 +43,12 @@ public class ListCommandTest {
     }
 
     @Test
-    /**
-     * Asserts that there an exception is thrown when the user enters a /tag without a value
-     */
     private void assertListByTagBehavior() {
         parser.resourceList = testResourceList;
         assertThrows(SysLibException.class, ()->listCommand.execute("/tag", parser));
 
     }
-
     @Test
-    /**
-     * Asserts that there an exception is thrown when the user enters a /g without a value
-     */
     private void assertListByGenreBehavior()  {
         parser.resourceList = testResourceList;
         assertThrows(SysLibException.class, ()->listCommand.execute("/g", parser));
@@ -66,9 +56,6 @@ public class ListCommandTest {
     }
 
     @Test
-    /**
-     * Asserts that there is no error when there are no resources to list with given filters.
-     */
     private void assertNoFilteredListDisplay() throws SysLibException {
         String outputMessage = testUtil.getOutputMessage(listCommand, "list /g Thriller", testResourceList);
         String expectedMessage = "Listing all resources matching given genre: " + System.lineSeparator()

--- a/src/test/java/seedu/util/TestUtil.java
+++ b/src/test/java/seedu/util/TestUtil.java
@@ -1,12 +1,14 @@
 package seedu.util;
 
 import seedu.commands.Command;
+import seedu.data.Book;
 import seedu.data.Resource;
 import seedu.data.SysLibException;
 import seedu.parser.Parser;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestUtil {
@@ -27,6 +29,21 @@ public class TestUtil {
         System.setOut(new PrintStream(outputStream));
         c.execute(m, parser);
         return outputStream.toString();
+    }
+
+    public static List<Resource> fillTestList() {
+        List<Resource> testResourceList = new ArrayList<>();
+        String[] genres = {"Horror", "Fiction"};
+        String[] genresAdventure = {"Adventure"};
+
+        Resource test1 = new Resource("title1", "123123");
+        Book testBook = new Book("title2", "123123", "author", genres, 123123);
+        Book testBook2 = new Book("title3", "123123", "author", genresAdventure, 123123);
+
+        testResourceList.add(test1);
+        testResourceList.add(testBook);
+        testResourceList.add(testBook2);
+        return testResourceList;
     }
 
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -19,5 +19,21 @@ find: (e.g. find /i 9780763630188)
 exit: (e.g. exit)
 For more information, please refer to our user guide at:https://ay2324s1-cs2113t-w11-1.github.io/tp/UserGuide.html
 ____________________________________________________________
+> Listing all resources in the Library: 
+
+1. [B]  ID: 123456789 Title: Moby Dick ISBN: 9780763630188 Author: Herman Melville Genre: Adventure, Fiction
+
+There are currently 1 resource(s).
+
+> Listing all resources matching given tag: 
+
+1. [B]  ID: 123456789 Title: Moby Dick ISBN: 9780763630188 Author: Herman Melville Genre: Adventure, Fiction
+
+There are currently 1 resource(s).
+
+> Listing all resources matching given genre: 
+
+There are currently 0 resource(s).
+
 > Bye, hope to see you again soon!
 ____________________________________________________________

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,4 +1,7 @@
 add /id 123456789 /t Moby Dick /a Herman Melville /tag B /i 9780763630188 /g Adventure, Fiction
 find /t Moby Dick
 help
+list
+list /tag B
+list /g Horror
 exit


### PR DESCRIPTION
To ensure ListCommand works as intended, add tests such as:
1. Ensure list does not crash SysLib if executed when there are no resources
2. Ensure missing values for tag and genre filter throws exception
3. Ensure listing with filters does not crash SysLib if there are no found resources matching filters