### PR TITLE
Fix bug where listing by genre crashes SysLib

### DIFF
--- a/src/main/java/seedu/commands/ListCommand.java
+++ b/src/main/java/seedu/commands/ListCommand.java
@@ -124,6 +124,11 @@ public class ListCommand extends Command {
 
     public boolean hasGenre(Book bookResource, String genre){
         String[] genres = bookResource.getGenre();
+
+        if (genres[0] == null ){
+            return false;
+        }
+
         for(int j =0; j < genres.length; j ++){
             if (genres[j].equals(genre)){
                 return true;

--- a/src/main/java/seedu/commands/ListCommand.java
+++ b/src/main/java/seedu/commands/ListCommand.java
@@ -127,14 +127,11 @@ public class ListCommand extends Command {
 
         if (genres[0] == null ){
             return false;
+        } else if (genres[0].contains(genre)) {
+            return true;
+        } else {
+            return false;
         }
-
-        for(int j =0; j < genres.length; j ++){
-            if (genres[j].equals(genre)){
-                return true;
-            }
-        }
-        return false;
     }
 
     public void filterBothTagGenre(List<Resource> matchedGenreResources, List<Resource> matchedTagResources){

--- a/src/test/java/seedu/util/TestUtil.java
+++ b/src/test/java/seedu/util/TestUtil.java
@@ -35,14 +35,17 @@ public class TestUtil {
         List<Resource> testResourceList = new ArrayList<>();
         String[] genres = {"Horror", "Fiction"};
         String[] genresAdventure = {"Adventure"};
+        String[] genresNull = {null};
 
         Resource test1 = new Resource("title1", "123123");
         Book testBook = new Book("title2", "123123", "author", genres, 123123);
         Book testBook2 = new Book("title3", "123123", "author", genresAdventure, 123123);
-
+        Book testBook3 = new Book("title3", "123123", "author", genresNull, 123123);
         testResourceList.add(test1);
         testResourceList.add(testBook);
         testResourceList.add(testBook2);
+        testResourceList.add(testBook3);
+
         return testResourceList;
     }
 


### PR DESCRIPTION
When a book is added without a genre, SysLib crashes when listing by genre

Hence,
-add a check to hasGenre method to return false when a book has no genre

Note in future developments, if createBook changes its method of creating genres array, this fix has to be updated