### PR TITLE
Fix incorrect return in parser for Status

### DIFF
--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -115,17 +115,19 @@ public class Parser {
                     args[4] = gMatcher.group(1).trim(); // isbn
                     if (sMatchFound){
                         args[5] = gMatcher.group(2).split("/s")[0].trim(); // genre
+                        args[6] = sMatcher.group(2).trim(); // status
                     } else{
                         args[5] = gMatcher.group(2).trim(); // genre
                     }
                 } else {
-                    args[4] = matcher.group(5).trim(); // isbn
-                }
-
-                if (sMatchFound) {
-                    args[6] = sMatcher.group(2).trim(); // status
-                } else {
-                    args[6] = "Available";
+                    args[5] = null; //genre
+                    if (sMatchFound) {
+                        args[4] = sMatcher.group(1).trim(); //isbn
+                        args[6] = sMatcher.group(2).trim(); // status
+                    } else {
+                        args[4] = matcher.group(5).trim(); //isbn
+                        args[6] = "Available";
+                    }
                 }
 
                 if (args[0].isEmpty() || args[1].isEmpty() || args[2].isEmpty() || args[3].isEmpty()
@@ -135,13 +137,13 @@ public class Parser {
                 }
             } else {
                 throw new SysLibException("Please use the format " +
-                        "'add /id ID /t TITLE /a AUTHOR /tag TAG /i ISBN [/s STATUS] [/g GENRE]'."
+                        "'add /id ID /t TITLE /a AUTHOR /tag TAG /i ISBN [/g GENRE /s STATUS]'."
                         + SEPARATOR_LINEDIVIDER);
             }
             return args;
         } catch (IllegalStateException | SysLibException e) {
             throw new SysLibException("Please use the format " +
-                    "'add /id ID /t TITLE /a AUTHOR /tag TAG /i ISBN [/s STATUS] [/g GENRE]'." + SEPARATOR_LINEDIVIDER);
+                    "'add /id ID /t TITLE /a AUTHOR /tag TAG /i ISBN [/g GENRE /s STATUS]'." + SEPARATOR_LINEDIVIDER);
         }
     }
 
@@ -158,7 +160,7 @@ public class Parser {
         String title = args[1]; // title
         String author = args[2]; // author
         String isbn = args[4]; // isbn
-        Status status = getStatusFromString(args[6]); // Get the status from the provided string
+        Status status = getStatusFromString(args[6]); // status
 
 
         String genre;

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -11,6 +11,7 @@ import java.io.PrintStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ParserTest {
 
@@ -168,7 +169,7 @@ class ParserTest {
 
     @Test
     public void testParseAddCommand() throws SysLibException {
-        // Test case 1: Valid input with /tag b
+        // Test case 1: Valid input with both genre and status
         String statement1 = "add /id 123456789 /t Moby Dick /a Herman Melville /tag B /i 9780763630188 " +
                 "/g Adventure, Fiction /s lost";
         String[] result = Parser.parseAddCommand(statement1);
@@ -181,10 +182,34 @@ class ParserTest {
         assertEquals("Adventure, Fiction", result[5]);
         assertEquals("lost", result[6]);
 
-        // Test case 2: Invalid input (missing /tag b)
-        String statement2 = "add /id 123456789 /t Moby Dick /a Herman Melville /tag C /i 9780763630188 " +
+        // Test case 2: Valid input without genre
+        String statement2 = "add /id 123 /t Moby Dick /a Herman Melville /tag B /i 9780763630188 /s lost";
+        result = Parser.parseAddCommand(statement2);
+
+        assertEquals("123", result[0]);
+        assertEquals("Moby Dick", result[1]);
+        assertEquals("Herman Melville", result[2]);
+        assertEquals("B", result[3]);
+        assertEquals("9780763630188", result[4]);
+        assertNull(result[5]);
+        assertEquals("lost", result[6]);
+
+        // Test case 3: Valid input without status and genre
+        String statement3 = "add /id 456 /t Moby Dick /a Herman Melville /tag B /i 9780763630188";
+        result = Parser.parseAddCommand(statement3);
+
+        assertEquals("456", result[0]);
+        assertEquals("Moby Dick", result[1]);
+        assertEquals("Herman Melville", result[2]);
+        assertEquals("B", result[3]);
+        assertEquals("9780763630188", result[4]);
+        assertNull(result[5]);
+        assertEquals("Available", result[6]);
+
+        // Test case 4: Invalid input (missing /tag b)
+        String statement4 = "add /id 123456789 /t Moby Dick /a Herman Melville /tag C /i 9780763630188 " +
                 "/g Adventure, Fiction /s Borrowed";
-        assertThrows(SysLibException.class, () -> Parser.parseAddCommand(statement2));
+        assertThrows(SysLibException.class, () -> Parser.parseAddCommand(statement4));
     }
 
     @Test


### PR DESCRIPTION
Fix incorrect return in ParseAddCommand() when parsing without genre but with status and without both status and genre
Add more test cases.