### PR TITLE
Add Filter by Status for List Command and fix logging for List, Edit

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,9 +187,9 @@ ____________________________________________________________
 ## List all items: `list` | [Return to contents](#contents)
 List all resources OR filter by certain tags or genre.
 
-Format: `list [/tag TAG /g GENRE ]`
-- Including both filters `tag` and `genre` will only list resources satisfying both criteria:
-    - `list /tag B /g Horror` will list Books with Horror genre.
+Format: `list [/tag TAG /g GENRE /s STATUS]`
+- Including more than one filter will only list resources satisfying **ALL** given filters:
+    - Example: `list /tag B /g Horror` will list Books with Horror genre.
 
 **Example input:**
 ```
@@ -197,6 +197,7 @@ list
 list /tag B
 list /tag B /g Fiction
 list /g Thrill
+list /s Available
 ```
 
 **Example output:**
@@ -384,7 +385,7 @@ ____________________________________________________________
 |-----------------------|------------------------------------------------------------------------------------------------------------|
 | Add listing           | `add /t <title of listing> /a <author of item> /tag <type of item> /i <ISBN of item> [/g <genre of item>]` |
 | Delete listing        | `delete /id <id of listing>`                                                                               |
-| Listing all items     | `list [/tag <type of item> /g <genre of book>]`                                                            |
+| Listing all items     | `list [/tag <type of item> /g <genre of item> /s <status of item>]`                                        |
 | Find specific listing | `find [/t <title of listing> OR /i <ISBN of item> OR /a AUTHOR OR /id ID]`                                 |
 | Edit a listing        | `edit /i ISBN [/t <title of listing> /a AUTHOR /id ID /tag <type of item> /g <genre of item>] /s <status>` |
 | Exit                  | `exit`                                                                                                     |

--- a/src/main/java/seedu/commands/EditCommand.java
+++ b/src/main/java/seedu/commands/EditCommand.java
@@ -8,6 +8,7 @@ import seedu.exception.SysLibException;
 import seedu.parser.Parser;
 
 
+import java.io.File;
 import java.io.IOException;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
@@ -15,8 +16,8 @@ import java.util.logging.Logger;
 import java.util.List;
 import java.util.logging.SimpleFormatter;
 
-import static seedu.common.Messages.formatLastLineDivider;
-import static seedu.common.Messages.formatLineSeparator;
+import static seedu.common.FormatMessages.formatLastLineDivider;
+import static seedu.common.FormatMessages.formatLineSeparator;
 
 public class EditCommand extends Command{
     public static final String MISSING_ARG_MESSAGE =  formatLastLineDivider("Please provide at least " +
@@ -30,14 +31,23 @@ public class EditCommand extends Command{
     private static int resourceIndex;
 
     static {
-        try {
-            FileHandler editFileHandler = new FileHandler("logs/editCommandLogs.log", true);
-            editFileHandler.setFormatter(new SimpleFormatter());
-            EDIT_LOGGER.addHandler(editFileHandler);
-        } catch (IOException e){
-            EDIT_LOGGER.log(Level.SEVERE,"Failed to set up Logging File Handler");
 
+        FileHandler editFileHandler = null;
+        try {
+            String loggingDirectoryPath = System.getProperty("user.dir") + "/logs";
+            String logFilePath = loggingDirectoryPath + "/editCommandLogs.log";
+            File directory = new File(loggingDirectoryPath);
+            if (!directory.exists()) {
+                directory.mkdir();
+            }
+            editFileHandler = new FileHandler(logFilePath, true);
+
+        } catch (IOException e) {
+            EDIT_LOGGER.log(Level.SEVERE, "Failed to initialize edit logging handler.");
+            throw new RuntimeException(e);
         }
+        editFileHandler.setFormatter(new SimpleFormatter());
+        EDIT_LOGGER.addHandler(editFileHandler);
     }
 
 

--- a/src/main/java/seedu/common/FormatMessages.java
+++ b/src/main/java/seedu/common/FormatMessages.java
@@ -3,7 +3,7 @@ package seedu.common;
 import static seedu.ui.UI.LINESEPARATOR;
 import static seedu.ui.UI.SEPARATOR_LINEDIVIDER;
 
-public class Messages {
+public class FormatMessages {
 
     public static String formatFirstLine(String message){
         return LINESEPARATOR + message + LINESEPARATOR + LINESEPARATOR;

--- a/src/test/java/seedu/commands/EditCommandTest.java
+++ b/src/test/java/seedu/commands/EditCommandTest.java
@@ -13,7 +13,7 @@ import seedu.util.TestUtil;
 
 import static seedu.commands.EditCommand.RESOURCE_NOT_FOUND;
 import static seedu.commands.EditCommand.EDIT_SUCCESS;
-import static seedu.common.Messages.formatLastLineDivider;
+import static seedu.common.FormatMessages.formatLastLineDivider;
 
 
 
@@ -65,8 +65,8 @@ public class EditCommandTest {
         executeEditSuccessBehavior("/i 2 /g Horror, Action, Fantasy");
     }
 
-    private void executeEditSuccessBehavior(String arguments) throws SysLibException {
-        String outputMessage = testUtil.getOutputMessage(editCommand, arguments, testResourceList);
+    private void executeEditSuccessBehavior(String argument) throws SysLibException {
+        String outputMessage = testUtil.getOutputMessage(editCommand, argument, testResourceList);
         String expectedMessage = EDIT_SUCCESS + formatLastLineDivider((testResourceList.get(1)).toString());
         assertEquals(expectedMessage, outputMessage);
     }

--- a/src/test/java/seedu/commands/ListCommandTest.java
+++ b/src/test/java/seedu/commands/ListCommandTest.java
@@ -15,6 +15,8 @@ import seedu.util.TestUtil;
 import static seedu.commands.ListCommand.GENERIC_MESSAGE;
 import static seedu.commands.ListCommand.FILTER_MESSAGE;
 import static seedu.commands.ListCommand.ZERO_RESOURCES_MESSAGE;
+import static seedu.commands.ListCommand.displayResourcesDetails;
+import static seedu.commands.ListCommand.matchedResources;
 
 
 
@@ -47,15 +49,49 @@ public class ListCommandTest {
     }
 
     @Test
-    public void testListByTagBehavior() {
+    public void testNoTagArgBehavior() {
         parser.resourceList = testResourceList;
         assertThrows(IllegalArgumentException.class, ()->listCommand.execute("/tag", parser));
 
     }
     @Test
-    public void testListByGenreBehavior()  {
+    public void testNoGenreArgBehavior()  {
         parser.resourceList = testResourceList;
         assertThrows(IllegalArgumentException.class, ()->listCommand.execute("/g", parser));
+
+    }
+
+    @Test
+    public void testNoStatusArgBehavior()  {
+        parser.resourceList = testResourceList;
+        assertThrows(IllegalArgumentException.class, ()->listCommand.execute("/s", parser));
+
+    }
+
+    @Test
+    public void testListByTagFilterBehavior() throws SysLibException {
+        executeListFilterBehavior("/tag B");
+    }
+
+    @Test
+    public void testListByGenreFilterBehavior() throws SysLibException {
+        executeListFilterBehavior("/g Horror");
+        executeListFilterBehavior("/g Adventure");
+        executeListFilterBehavior("/g Fiction");
+    }
+
+    @Test
+    public void testListByStatusFilterBehavior() throws SysLibException {
+        executeListFilterBehavior("/s AVAILABLE");
+
+    }
+
+
+
+    public void executeListFilterBehavior(String argument) throws SysLibException {
+        String outputMessage = testUtil.getOutputMessage(listCommand, argument, testResourceList);
+        String expectedMessage = FILTER_MESSAGE + displayResourcesDetails(matchedResources);
+        assertEquals(expectedMessage, outputMessage);
 
     }
 


### PR DESCRIPTION
Librarians may want get an overview of the status of resources

Hence, add filter by status to list for AVAILABLE, BORROWED, LOST and add more test cases

Fix list and edit logging where ./runtest.bat fails due to missing log directory

Rename Messages class to FormatMessages to reflect its purpose clearly